### PR TITLE
Added indentation rules

### DIFF
--- a/Preferences/Indentation rules.tmPreferences
+++ b/Preferences/Indentation rules.tmPreferences
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Indentation rules</string>
+	<key>scope</key>
+	<string>source.scss</string>
+	<key>settings</key>
+	<dict>
+		<key>decreaseIndentPattern</key>
+		<string>^\s*\}</string>
+		<key>increaseIndentPattern</key>
+		<string>(^.*\{[^}]*$)</string>
+	</dict>
+	<key>uuid</key>
+	<string>2E4DDA47-1FC3-4FF7-A719-49ED6FA8ECFF</string>
+</dict>
+</plist>


### PR DESCRIPTION
This means you can now use the Text -> Indent Line / Selection feature in
Textmate and it will properly re-indent the document. Work beset if you have
the closing } on it's own line though.
