### PR TITLE
Added command to compile from SCSS to CSS

### DIFF
--- a/Commands/SCSS =%3E CSS.tmCommand
+++ b/Commands/SCSS =%3E CSS.tmCommand
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>beforeRunningCommand</key>
+	<string>saveActiveFile</string>
+	<key>command</key>
+	<string>#!/bin/sh
+PATH=$PATH:$SASS_DIR
+CSS=${TM_FILEPATH/.scss/.css}
+SASS_OPTS="-t compact"
+sass ${SASS_OPTS} --update "${TM_FILEPATH}":"${CSS}"</string>
+	<key>input</key>
+	<string>none</string>
+	<key>keyEquivalent</key>
+	<string>^@r</string>
+	<key>name</key>
+	<string>SCSS =&gt; CSS</string>
+	<key>output</key>
+	<string>showAsTooltip</string>
+	<key>uuid</key>
+	<string>78345399-B86D-4A76-B211-BF75190906EA</string>
+</dict>
+</plist>


### PR DESCRIPTION
Hi!
I just added a little command which compiles the current SCSS to CSS in the same directory.
This command references environment variable SASS_DIR to specify the path of sass executable.
I choose the style compact because is the only style i use in my applications.
I also added a shortcut, which is Ctrl+Cmd+R
Hope this helps!
Best regards!
   Shogun
