### PR TITLE
Use SCSS syntax highlighting when using the .erb file extension for SCSS 

### DIFF
--- a/Syntaxes/SCSS.tmLanguage
+++ b/Syntaxes/SCSS.tmLanguage
@@ -7,6 +7,7 @@
 	<key>fileTypes</key>
 	<array>
 		<string>scss</string>
+		<string>scss.erb</string>
 	</array>
 	<key>foldingStartMarker</key>
 	<string>/\*\*(?!\*)|\{\s*($|/\*(?!.*?\*/.*\S))</string>


### PR DESCRIPTION
Use SCSS syntax highlighting when using the .erb file extension for SCSS files. Useful when you use the asset_path file helper in CSS files (for instance when specifying a list-style-image).
