### PR TITLE
Sublime Text 2 Keybindings

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,0 +1,27 @@
+[
+	{ "keys": [":"], "command": "insert_snippet", "args": {"contents": ":$0;"}, "context":
+		[
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.scss - meta.selector.scss", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\}|$)", "match_all": true }
+		]
+	},
+	{ "keys": [";"], "command": "move", "args": {"by": "characters", "forward": true}, "context":
+		[
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.scss - meta.selector.scss", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^;", "match_all": true }
+		]
+	},
+	{ "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "Packages/Default/Delete Left Right.sublime-macro"}, "context":
+		[
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.scss - meta.selector.scss", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": ":$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^;", "match_all": true }
+		]
+	}
+]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,0 +1,27 @@
+[
+	{ "keys": [":"], "command": "insert_snippet", "args": {"contents": ":$0;"}, "context":
+		[
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.scss - meta.selector.scss", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\}|$)", "match_all": true }
+		]
+	},
+	{ "keys": [";"], "command": "move", "args": {"by": "characters", "forward": true}, "context":
+		[
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.scss - meta.selector.scss", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^;", "match_all": true }
+		]
+	},
+	{ "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "Packages/Default/Delete Left Right.sublime-macro"}, "context":
+		[
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.scss - meta.selector.scss", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": ":$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^;", "match_all": true }
+		]
+	}
+]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,0 +1,27 @@
+[
+	{ "keys": [":"], "command": "insert_snippet", "args": {"contents": ":$0;"}, "context":
+		[
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.scss - meta.selector.scss", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^(?:\t| |\\}|$)", "match_all": true }
+		]
+	},
+	{ "keys": [";"], "command": "move", "args": {"by": "characters", "forward": true}, "context":
+		[
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.scss - meta.selector.scss", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^;", "match_all": true }
+		]
+	},
+	{ "keys": ["backspace"], "command": "run_macro_file", "args": {"file": "Packages/Default/Delete Left Right.sublime-macro"}, "context":
+		[
+			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
+			{ "key": "selection_empty", "operator": "equal", "operand": true, "match_all": true },
+			{ "key": "selector", "operator": "equal", "operand": "source.scss - meta.selector.scss", "match_all": true },
+			{ "key": "preceding_text", "operator": "regex_contains", "operand": ":$", "match_all": true },
+			{ "key": "following_text", "operator": "regex_contains", "operand": "^;", "match_all": true }
+		]
+	}
+]


### PR DESCRIPTION
Here are the ST2 keybindings needed to get a few autocompletes back, including the `: → ;` key pair.

Since these files are meaningless to TextMate, I'm not sure if you want to include these with master or start a ST2 branch.
