### PR TITLE
Revert scope back to source.scss

### DIFF
--- a/SCSS.tmLanguage
+++ b/SCSS.tmLanguage
@@ -1473,7 +1473,7 @@
 		</dict>
 	</dict>
 	<key>scopeName</key>
-	<string>source.css.scss</string>
+	<string>source.scss</string>
 	<key>uuid</key>
 	<string>3D9ADE5E-ADC5-460F-97B3-B61EF5A18273</string>
 </dict>


### PR DESCRIPTION
Changed scope back to source.scss until version 2.0 to resolve snippet issues.
