### PR TITLE
fixing missing #options in textmate log and fix bundle menu

### DIFF
--- a/Snippets/+ Shortcut to Include.tmSnippet
+++ b/Snippets/+ Shortcut to Include.tmSnippet
@@ -5,7 +5,7 @@
 	<key>content</key>
 	<string>@include ${0};</string>
 	<key>name</key>
-	<string>+ Shortcut to Include</string>
+	<string>+ Shortcut to @include</string>
 	<key>scope</key>
 	<string>source.css, source.scss</string>
 	<key>tabTrigger</key>

--- a/Syntaxes/SCSS.tmLanguage
+++ b/Syntaxes/SCSS.tmLanguage
@@ -61,7 +61,7 @@
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#option</string>
+			<string>#at_rule_option</string>
 		</dict>
 	</array>
 	<key>repository</key>

--- a/info.plist
+++ b/info.plist
@@ -3,9 +3,84 @@
 <plist version="1.0">
 <dict>
 	<key>mainMenu</key>
-	<dict/>
+	<dict>
+		<key>items</key>
+		<array>
+			<string>164A8B30-3626-45A3-A599-2D2B41B3C3CE</string>
+			<string>------------------------------------</string>
+			<string>24605721-E0AA-4F0E-8311-6219290C7A94</string>
+			<string>852E0119-7EC8-4435-A414-8937E6289D8C</string>
+			<string>------------------------------------</string>
+			<string>C5012C1B-2078-47B2-9E60-1CDE6B555AB8</string>
+			<string>5AC218D8-49AC-4E26-B793-FDC7EC833F93</string>
+			<string>------------------------------------</string>
+			<string>6E3966B1-E185-466E-A893-169D85C643E0</string>
+			<string>D51A613E-4198-4FAB-99CC-9981EF99BE39</string>
+		</array>
+		<key>submenus</key>
+		<dict>
+			<key>164A8B30-3626-45A3-A599-2D2B41B3C3CE</key>
+			<dict>
+				<key>items</key>
+				<array>
+					<string>591BE979-E7D8-433B-A5F0-D8B96E510BC9</string>
+					<string>D4E56475-16C0-4DB3-BEFF-9FBC4F83C166</string>
+					<string>6764DCFD-20D0-4838-BDA0-7CE38A3AFE0C</string>
+					<string>3A9E3BFE-2B1B-4E85-818F-93EEF8543813</string>
+					<string>ECD46162-8C51-4E8C-A859-CC0B5AD320AC</string>
+					<string>C2197513-C7E2-43A6-B3CB-84EFBBEC89D1</string>
+					<string>CFEDC20F-4714-4C88-81B4-1C5D149DA04D</string>
+					<string>A24F91CB-A3E5-4907-8259-5E7645E39BAF</string>
+					<string>0D6354D0-B50E-47A8-9F42-C9B452660340</string>
+				</array>
+				<key>name</key>
+				<string>Snippets</string>
+			</dict>
+			<key>6E3966B1-E185-466E-A893-169D85C643E0</key>
+			<dict>
+				<key>items</key>
+				<array>
+					<string>4E2E7138-69AA-4BF1-A87E-8C45DE807B10</string>
+					<string>78345399-B86D-4A76-B211-BF75190906EA</string>
+					<string>49B13F70-B978-4633-AB69-8D2AB64C870E</string>
+				</array>
+				<key>name</key>
+				<string>Conversion</string>
+			</dict>
+		</dict>
+	</dict>
 	<key>name</key>
 	<string>SCSS</string>
+	<key>ordering</key>
+	<array>
+		<string>ECD46162-8C51-4E8C-A859-CC0B5AD320AC</string>
+		<string>C2197513-C7E2-43A6-B3CB-84EFBBEC89D1</string>
+		<string>CFEDC20F-4714-4C88-81B4-1C5D149DA04D</string>
+		<string>A24F91CB-A3E5-4907-8259-5E7645E39BAF</string>
+		<string>591BE979-E7D8-433B-A5F0-D8B96E510BC9</string>
+		<string>D4E56475-16C0-4DB3-BEFF-9FBC4F83C166</string>
+		<string>6764DCFD-20D0-4838-BDA0-7CE38A3AFE0C</string>
+		<string>3A9E3BFE-2B1B-4E85-818F-93EEF8543813</string>
+		<string>C5012C1B-2078-47B2-9E60-1CDE6B555AB8</string>
+		<string>5AC218D8-49AC-4E26-B793-FDC7EC833F93</string>
+		<string>2E4DDA47-1FC3-4FF7-A719-49ED6FA8ECFF</string>
+		<string>24605721-E0AA-4F0E-8311-6219290C7A94</string>
+		<string>852E0119-7EC8-4435-A414-8937E6289D8C</string>
+		<string>3D9ADE5E-ADC5-460F-97B3-B61EF5A18273</string>
+		<string>78345399-B86D-4A76-B211-BF75190906EA</string>
+		<string>49B13F70-B978-4633-AB69-8D2AB64C870E</string>
+		<string>4E2E7138-69AA-4BF1-A87E-8C45DE807B10</string>
+		<string>D51A613E-4198-4FAB-99CC-9981EF99BE39</string>
+		<string>0D6354D0-B50E-47A8-9F42-C9B452660340</string>
+		<string>5A98FD1D-9FB8-4EA5-9006-618E1A3F4122</string>
+		<string>11D969E1-6E76-47B2-9BAE-B5545064AB31</string>
+		<string>58AB9A66-307B-4214-B0C8-D31B9BEC0372</string>
+		<string>081DA7F0-1501-42D3-A287-3411457F4D62</string>
+		<string>71806A42-4B5B-4CE5-AFA0-60DC5C0AAF0F</string>
+		<string>FCC5C2D2-A56A-49DF-958C-BCECB5F24D74</string>
+		<string>FE87A88E-73FB-41EA-8A1E-9F7681C0F25A</string>
+		<string>B407385D-9891-4822-B06D-B82DBB6B98F0</string>
+	</array>
 	<key>uuid</key>
 	<string>BCEB5483-E029-479F-95AC-D6AADF98138F</string>
 </dict>


### PR DESCRIPTION
In response to #75

It appears that the #options parameter was never renamed to "#at_rule_options" like the other patterns in the Syntaxes/SCSS.tmbundle file.

Also, when the Zen snippets were removed the info.plist menu was cleared out, removing all menu items from the TextMate 1 SCSS bundle menu. The changes in info.plist fix the menu.
