### PR TITLE
Adding support for placeholder selectors

### DIFF
--- a/SCSS.tmLanguage
+++ b/SCSS.tmLanguage
@@ -1428,6 +1428,21 @@
 			<key>name</key>
 			<string>entity.other.attribute-name.pseudo-element.css</string>
 		</dict>
+		<key>selector_placeholder</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.entity.css</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(\%)[a-zA-Z0-9_-]+</string>
+			<key>name</key>
+			<string>entity.other.attribute-name.placeholder.css</string>
+		</dict>
 		<key>selectors</key>
 		<dict>
 			<key>comment</key>
@@ -1465,6 +1480,10 @@
 				<dict>
 					<key>include</key>
 					<string>#selector_attribute</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#selector_placeholder</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
This pull request adds support for SASS 3.2's new [placeholder](http://sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html#placeholder_selectors_) (%foo) selector.
