### PR TITLE
Adds support for !default, !optional

### DIFF
--- a/SCSS.tmLanguage
+++ b/SCSS.tmLanguage
@@ -204,6 +204,10 @@
 					<key>include</key>
 					<string>#selectors</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#property_values</string>
+				</dict>
 			</array>
 		</dict>
 		<key>at_rule_for</key>


### PR DESCRIPTION
This pull request adds support for the [!default](http://sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html#variable_defaults_) and [!optional](http://sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html#the__flag) SASS flags.
