### PR TITLE
Fix to compatible with css syntax

### DIFF
--- a/Syntaxes/SCSS.tmLanguage
+++ b/Syntaxes/SCSS.tmLanguage
@@ -2012,7 +2012,7 @@
 		</dict>
 	</dict>
 	<key>scopeName</key>
-	<string>source.scss</string>
+	<string>source.css.scss</string>
 	<key>uuid</key>
 	<string>3D9ADE5E-ADC5-460F-97B3-B61EF5A18273</string>
 </dict>


### PR DESCRIPTION
So, we can use text[tab] do some bundle complete like css files.
