### PR TITLE
Create SCSS.sublime-settings

### DIFF
--- a/SCSS.sublime-settings
+++ b/SCSS.sublime-settings
@@ -1,0 +1,4 @@
+{
+  "extensions": ["scss", "scss.erb"],
+  "hidden_extensions": ["sublime-snippet", "tmLanguage", "tmTheme", "tmSnippet", "tmPreferences"]
+}


### PR DESCRIPTION
This file gives some extra information to sublimetext about the 
extensions that should be highlighted with this syntax.

.scss is obvious, but 99,99% of the times, files that mixes some erb
logic, with the extension scss.erb, should also be opened with scss
syntax.

Specially usefull to Ruby on Rails developers that use sprokets to chain
preprocessors.
