### PR TITLE
Correct Invalid UUID

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -17,7 +17,7 @@
 			<string>------------------------------------</string>
 			<string>164A8B30-3626-45A3-A599-2D2B41B3C3CE</string>
 			<string>964A8B30-3626-45A3-A599-2D2B41B3C3CB</string>
-			<string>746A8B30-3626-45A3-A599-2D2B41B3C3ZB</string>
+			<string>9E4E44BF-A508-41B0-A75F-71361268FB9C</string>
 			<string>30892348-4559-49B9-BE5F-9C2C0A04ACC5</string>
 			<string>C6F1D660-63C4-4810-8499-69951145443A</string>
 			<string>0D6354D0-B50E-47A8-9F42-C9B452660340</string>
@@ -48,7 +48,7 @@
 				<key>name</key>
 				<string>@-Rules</string>
 			</dict>
-			<key>746A8B30-3626-45A3-A599-2D2B41B3C3ZB</key>
+			<key>9E4E44BF-A508-41B0-A75F-71361268FB9C</key>
 			<dict>
 				<key>items</key>
 				<array>


### PR DESCRIPTION
The UUID of one of the menu items contained a Z character which isn't allowed.
