### PR TITLE
fixed incorrect syntax highlighting for some file types

### DIFF
--- a/SCSS.sublime-settings
+++ b/SCSS.sublime-settings
@@ -1,4 +1,4 @@
 {
   "extensions": ["scss", "scss.erb"],
-  "hidden_extensions": ["sublime-snippet", "tmLanguage", "tmTheme", "tmSnippet", "tmPreferences"]
+  "hidden_extensions": []
 }


### PR DESCRIPTION
Removed the contents of the `"hidden_extensions"` list, which was causing files like `.tmTheme`, `.tmLanguage`, and `.sublime-snippet` to open with SCSS syntax highlighting instead of the appropriate language. I suspect this was left over from a copy-and-paste from another bundle/plugin, and nobody noticed it until now.
