### PR TITLE
Update comments.tmPreferences

### DIFF
--- a/Preferences/comments.tmPreferences
+++ b/Preferences/comments.tmPreferences
@@ -16,12 +16,6 @@
 				<key>value</key>
 				<string>//</string>
 			</dict>
-			<dict>
-				<key>name</key>
-				<string>TM_COMMENT_DISABLE_INDENT</string>
-				<key>value</key>
-				<string>yes</string>
-			</dict>
 		</array>
 	</dict>
 	<key>uuid</key>


### PR DESCRIPTION
I removed the (for me) extremely annoying indentation issue when commenting with `cmd + /`: as in _every_ other TM (or Sublime anyway) bundle, commenting through `cmd + /` causes the comment to start from the most left-indented line of text, and not from column 0 every time.
