### PR TITLE
Fix underscore character missing in grammar

### DIFF
--- a/Syntaxes/SCSS.tmLanguage
+++ b/Syntaxes/SCSS.tmLanguage
@@ -485,11 +485,11 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#string-double</string>
+					<string>#string_double</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#string-single</string>
+					<string>#string_single</string>
 				</dict>
 				<dict>
 					<key>begin</key>
@@ -527,11 +527,11 @@
 						</dict>
 						<dict>
 							<key>include</key>
-							<string>#string-single</string>
+							<string>#string_single</string>
 						</dict>
 						<dict>
 							<key>include</key>
-							<string>#string-double</string>
+							<string>#string_double</string>
 						</dict>
 					</array>
 				</dict>


### PR DESCRIPTION
I've found that the hash name "string-single" and "string-double" are not defined in the grammar's repository, so replace the word's separator by underscore character.
