### PR TITLE
Add begin and end tokens to selector patterns to get symbol list working again.

### DIFF
--- a/Syntaxes/SCSS.tmLanguage
+++ b/Syntaxes/SCSS.tmLanguage
@@ -1828,7 +1828,7 @@
 		<key>selectors</key>
 		<dict>
 			<key>begin</key>
-			<string>^[ \t]*(?=[@&amp;*:.#+&gt;\-_a-zA-Z\d ,\[\]=\^!|~$]+\n)</string>
+			<string>^[ \t]*(?=[@&amp;*:.#+&gt;\-_a-zA-Z\d ,\[\]\(\)=\^!|~$]+\n)</string>
 			<key>comment</key>
 			<string>Stuff for Selectors.</string>
 			<key>end</key>


### PR DESCRIPTION
Fixes #136. 
