### PR TITLE
Disable smart typing pairs for colon due to usability reasons

### DIFF
--- a/Preferences/smart typing pairs.tmPreferences
+++ b/Preferences/smart typing pairs.tmPreferences
@@ -35,10 +35,6 @@
 				<string>'</string>
 			</array>
 			<array>
-				<string>:</string>
-				<string>;</string>
-			</array>
-			<array>
 				<string>/*</string>
 				<string>*/</string>
 			</array>


### PR DESCRIPTION
The smart typing pairs setting for colon automatically completes with
a semicolon, but this is not ideal, since it adds the semicolon on
undersired situations, such as when writing pseudo elements like
:before and :after.

This is a bit annoying when writing code since time must be spent
deleting the undesired semicolons added by this setting.

This commit removes automatic completion of colon/semicolon.
